### PR TITLE
[FIX] showing the navigation_type name

### DIFF
--- a/src/FilamentNavigationManager.php
+++ b/src/FilamentNavigationManager.php
@@ -18,7 +18,7 @@ class FilamentNavigationManager
     public function addItemType(string $name, array | Closure $fields = []): static
     {
         $this->itemTypes[Str::slug($name)] = [
-            'name' => 'name',
+            'name' => $name,
             'fields' => $fields,
         ];
 


### PR DESCRIPTION
You wasn't showing the navigation _type item name in the options list as you were setting it to a fixed value ''name'