### PR TITLE
fix: entangle-based components not working in item modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/dbal": "^3.3",
-        "filament/filament": "^2.0",
+        "filament/filament": "^2.13",
         "illuminate/contracts": "^9.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },

--- a/resources/views/navigation-builder.blade.php
+++ b/resources/views/navigation-builder.blade.php
@@ -25,7 +25,7 @@
     </div>
 
     <div class="flex justify-end">
-        <x-filament::button wire:click="mountAction('item')" type="button" size="sm" color="secondary">
+        <x-filament::button wire:click="createItem" type="button" size="sm" color="secondary">
             Add Item
         </x-filament::button>
     </div>

--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -133,7 +133,9 @@ trait HandlesNavigationBuilder
         return [
             Action::make('item')
                 ->mountUsing(function (ComponentContainer $form) {
-                    $form->fill($this->mountedItemData);
+                    if ($this->mountedItem) {
+                        $form->fill($this->mountedItemData);
+                    }
                 })
                 ->view('filament-navigation::hidden-action')
                 ->form([

--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -3,7 +3,9 @@
 namespace RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\Concerns;
 
 use Closure;
+use Filament\Facades\Filament;
 use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -12,6 +14,8 @@ use Filament\Pages\Actions\Action;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RyanChandler\FilamentNavigation\Facades\FilamentNavigation;
+use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\CreateNavigation;
+use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\EditNavigation;
 
 trait HandlesNavigationBuilder
 {
@@ -146,6 +150,18 @@ trait HandlesNavigationBuilder
                             $types = FilamentNavigation::getItemTypes();
 
                             return array_combine(array_keys($types), Arr::pluck($types, 'name'));
+                        })
+                        ->afterStateUpdated(function ($state, Select $component): void {
+                            if (! $state) return;
+
+                            // NOTE: This chunk of code is a workaround for Livewire not letting
+                            //       you entangle to non-existent array keys, which wire:model
+                            //       would normally let you do.
+                            $component
+                                ->getContainer()
+                                ->getComponent(fn (Component $component) => $component instanceof Group)
+                                ->getChildComponentContainer()
+                                ->fill();
                         })
                         ->reactive(),
                     Group::make()

--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -3,7 +3,6 @@
 namespace RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\Concerns;
 
 use Closure;
-use Filament\Facades\Filament;
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Group;
@@ -14,8 +13,6 @@ use Filament\Pages\Actions\Action;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RyanChandler\FilamentNavigation\Facades\FilamentNavigation;
-use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\CreateNavigation;
-use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\EditNavigation;
 
 trait HandlesNavigationBuilder
 {
@@ -163,7 +160,9 @@ trait HandlesNavigationBuilder
                             return array_combine(array_keys($types), Arr::pluck($types, 'name'));
                         })
                         ->afterStateUpdated(function ($state, Select $component): void {
-                            if (! $state) return;
+                            if (! $state) {
+                                return;
+                            }
 
                             // NOTE: This chunk of code is a workaround for Livewire not letting
                             //       you entangle to non-existent array keys, which wire:model

--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -132,14 +132,25 @@ trait HandlesNavigationBuilder
         $this->mountAction('item');
     }
 
+    public function createItem()
+    {
+        $this->mountedItem = null;
+        $this->mountedItemData = [];
+        $this->mountedActionData = [];
+
+        $this->mountAction('item');
+    }
+
     protected function getActions(): array
     {
         return [
             Action::make('item')
                 ->mountUsing(function (ComponentContainer $form) {
-                    if ($this->mountedItem) {
-                        $form->fill($this->mountedItemData);
+                    if (! $this->mountedItem) {
+                        return;
                     }
+
+                    $form->fill($this->mountedItemData);
                 })
                 ->view('filament-navigation::hidden-action')
                 ->form([
@@ -196,6 +207,8 @@ trait HandlesNavigationBuilder
                             ...['children' => []],
                         ];
                     }
+
+                    $this->mountedActionData = [];
                 })
                 ->modalButton('Save')
                 ->label('Item'),


### PR DESCRIPTION
Closes #15.

Livewire doesn't let you entangle non-existent array keys, unlike `wire:model`. That was the main problem here.

Another problem I've spotted is that the action modal is being cached / not being refreshed between items. Will likely need to use a custom modal to handle this instead, hence the draft PR.