### PR TITLE
[Fix] Minimum required filament version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/dbal": "^3.3",
-        "filament/filament": "^2.0",
+        "filament/filament": "^2.10.34",
         "illuminate/contracts": "^9.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },


### PR DESCRIPTION
$ignoreRecord has been added with [2.10.34](https://github.com/laravel-filament/filament/blob/64970a41c234261b5180169b04c688a064d935c3/packages/forms/src/Components/Concerns/CanBeValidated.php#L129).

It is being used [here](https://github.com/ryangjchandler/filament-navigation/blob/f782cd1509e86ad87c8001bd3d7f44d394cb035c/src/Filament/Resources/NavigationResource.php#L609) and does cause the tests to fail as they install Filament version 2.9