### PR TITLE
Fix actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,11 @@
         "test-coverage": "vendor/bin/pest coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest coverage"
+        "test-coverage": "vendor/bin/pest coverage",
+        "format": "vendor/bin/php-cs-fixer fix --config=.php_cs.dist.php --allow-risky=yes"
     },
     "config": {
         "sort-packages": true,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,13 +2,13 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - config
         - database
     tmpDir: build/phpstan
+    reportUnmatchedIgnoredErrors: true
     checkOctaneCompatibility: true
     checkModelProperties: true
     checkMissingIterableValueType: false
-

--- a/src/Filament/Resources/NavigationResource.php
+++ b/src/Filament/Resources/NavigationResource.php
@@ -89,32 +89,32 @@ class NavigationResource extends Resource
 
     public static function navigationLabel(?string $string): void
     {
-        static::$workNavigationLabel = $string;
+        self::$workNavigationLabel = $string;
     }
 
     public static function pluralLabel(?string $string): void
     {
-        static::$workPluralLabel = $string;
+        self::$workPluralLabel = $string;
     }
 
     public static function label(?string $string): void
     {
-        static::$workLabel = $string;
+        self::$workLabel = $string;
     }
 
     protected static function getNavigationLabel(): string
     {
-        return static::$workNavigationLabel ?? parent::getNavigationLabel();
+        return self::$workNavigationLabel ?? parent::getNavigationLabel();
     }
 
     public static function getLabel(): ?string
     {
-        return static::$workLabel ?? parent::getLabel();
+        return self::$workLabel ?? parent::getLabel();
     }
 
     public static function getPluralLabel(): ?string
     {
-        return static::$workPluralLabel ?? parent::getPluralLabel();
+        return self::$workPluralLabel ?? parent::getPluralLabel();
     }
 
     public static function table(Table $table): Table


### PR DESCRIPTION
- Fix error action `composer install`
    ```
    Error: pestphp/pest-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
    ```
- Fix phpstan
    ```
    Unsafe access to `private` property {file}  through `static::`.
    ```
- Add `format` script, to make sure run before PR
- Add `reportUnmatchedIgnoredErrors`

---

Test actions : https://github.com/Kristories/filament-navigation/actions
