### PR TITLE
Add method to define global extra-fields for all item-types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ use RyanChandler\FilamentNavigation\Facades\FilamentNavigation;
 $menu = FilamentNavigation::get('main-menu');
 ```
 
+### Extra fields
+
+You can register global extra fields for all registered item-types (e.g. to specify class-attributes).
+
+```php
+use RyanChandler\FilamentNavigation\Facades\FilamentNavigation;
+
+FilamentNavigation::addExtraFields([
+    TextInput::make('item_class')
+    // ...
+]);
+```
+
 ### Custom item types
 
 Out of the box, this plugin comes with a single "item type" called "External link". This item type expects a URL to be provided and an optional "target" (same tab or new tab).

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1",
         "doctrine/dbal": "^3.3",
         "filament/filament": "^2.13",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {

--- a/src/FilamentNavigationManager.php
+++ b/src/FilamentNavigationManager.php
@@ -13,13 +13,19 @@ class FilamentNavigationManager
 {
     use Macroable;
 
+    protected array $extraFields = [];
     protected array $itemTypes = [];
+
+    public function addExtraFields(array | Closure $fields = []) {
+        $this->extraFields = array_merge($this->extraFields, $fields);
+        return $this;
+    }
 
     public function addItemType(string $name, array | Closure $fields = []): static
     {
         $this->itemTypes[Str::slug($name)] = [
             'name' => $name,
-            'fields' => $fields,
+            'fields' => array_merge($fields, $this->extraFields),
         ];
 
         return $this;
@@ -46,6 +52,7 @@ class FilamentNavigationManager
                             '_blank' => __('filament-navigation::filament-navigation.select-options.new-tab'),
                         ])
                         ->default(''),
+                    ...$this->extraFields
                 ],
             ],
         ], $this->itemTypes);


### PR DESCRIPTION
Add new method to define global extra-fields (e.g. to specify class-attributes) for all item-types.