### PR TITLE
 add slug param to addItemType

### DIFF
--- a/src/FilamentNavigationManager.php
+++ b/src/FilamentNavigationManager.php
@@ -15,9 +15,12 @@ class FilamentNavigationManager
 
     protected array $itemTypes = [];
 
-    public function addItemType(string $name, array | Closure $fields = []): static
+    public function addItemType(string $name, array | Closure $fields = [], string | null $slug = null): static
     {
-        $this->itemTypes[Str::slug($name)] = [
+
+        $slug = empty($slug) ? Str::slug($name): $slug;
+
+        $this->itemTypes[$slug] = [
             'name' => $name,
             'fields' => $fields,
         ];


### PR DESCRIPTION
`Str::slug($name)` for languages like Arabic gives unexpected names. adding an additional parameter to let the developer pass custom slug, will solve the problem