### PR TITLE
fix when using with multiple panels

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/CreateNavigation.php
+++ b/src/Filament/Resources/NavigationResource/Pages/CreateNavigation.php
@@ -2,7 +2,9 @@
 
 namespace RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Pages\CreateRecord;
+use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource;
 use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\Concerns\HandlesNavigationBuilder;
 use RyanChandler\FilamentNavigation\FilamentNavigation;
 
@@ -12,6 +14,10 @@ class CreateNavigation extends CreateRecord
 
     public static function getResource(): string
     {
-        return FilamentNavigation::get()->getResource();
+        if (Filament::hasPlugin('navigation')) {
+            return FilamentNavigation::get()->getResource();
+        }
+
+        return NavigationResource::class;
     }
 }

--- a/src/Filament/Resources/NavigationResource/Pages/EditNavigation.php
+++ b/src/Filament/Resources/NavigationResource/Pages/EditNavigation.php
@@ -2,7 +2,9 @@
 
 namespace RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Pages\EditRecord;
+use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource;
 use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages\Concerns\HandlesNavigationBuilder;
 use RyanChandler\FilamentNavigation\FilamentNavigation;
 
@@ -12,6 +14,10 @@ class EditNavigation extends EditRecord
 
     public static function getResource(): string
     {
-        return FilamentNavigation::get()->getResource();
+        if (Filament::hasPlugin('navigation')) {
+            return FilamentNavigation::get()->getResource();
+        }
+
+        return NavigationResource::class;
     }
 }

--- a/src/Filament/Resources/NavigationResource/Pages/ListNavigations.php
+++ b/src/Filament/Resources/NavigationResource/Pages/ListNavigations.php
@@ -3,14 +3,20 @@
 namespace RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource\Pages;
 
 use Filament\Actions\CreateAction;
+use Filament\Facades\Filament;
 use Filament\Resources\Pages\ListRecords;
+use RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource;
 use RyanChandler\FilamentNavigation\FilamentNavigation;
 
 class ListNavigations extends ListRecords
 {
     public static function getResource(): string
     {
-        return FilamentNavigation::get()->getResource();
+        if (Filament::hasPlugin('navigation')) {
+            return FilamentNavigation::get()->getResource();
+        }
+
+        return NavigationResource::class;
     }
 
     protected function getActions(): array


### PR DESCRIPTION
Fix when using the plugin with multiple panels
will get the error

`Plugin [navigation] is not registered for panel [team].`