### PR TITLE
clear add child form before showing

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -39,6 +39,9 @@ trait HandlesNavigationBuilder
     {
         $this->mountedChildTarget = $statePath;
 
+        $this->mountedItem = null;
+        $this->mountedActionData = [];
+
         $this->mountAction('item');
     }
 


### PR DESCRIPTION
**Problem**
In the navigation, 
1. If you click edit an item, popup will show with form pre-filled, 
2. Cancel the popup and then click on add child, 
3. add child popup will show the previous data filled in form.

**Solution**
I added 
`$this->mountedItem = null;
  $this->mountedActionData = [];`

in addChild function in HandlesNavigationBuilder trait 