### PR TITLE
Ordering issues with associative array

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -26,10 +26,7 @@ trait HandlesNavigationBuilder
         $items = [];
 
         foreach ($targetItemsStatePaths as $targetItemStatePath) {
-            $item = data_get($this, $targetItemStatePath);
-            $uuid = Str::afterLast($targetItemStatePath, '.');
-
-            $items[$uuid] = $item;
+            $items[] = data_get($this, $targetItemStatePath);
         }
 
         data_set($this, $targetStatePath, $items);
@@ -132,7 +129,7 @@ trait HandlesNavigationBuilder
                     } elseif ($this->mountedChildTarget) {
                         $children = data_get($this, $this->mountedChildTarget . '.children', []);
 
-                        $children[(string) Str::uuid()] = [
+                        $children[] = [
                             ...$data,
                             ...['children' => []],
                         ];
@@ -141,7 +138,7 @@ trait HandlesNavigationBuilder
 
                         $this->mountedChildTarget = null;
                     } else {
-                        $this->data['items'][(string) Str::uuid()] = [
+                        $this->data['items'][] = [
                             ...$data,
                             ...['children' => []],
                         ];


### PR DESCRIPTION
Fix ordering issues by using regular arrays instead of associative arrays. Existing code should work as is, thanks to PHP handling both kinds of arrays the same way.

This is a proposition of fix that highlights a problem: There's an issue with sorting.

Sorting is always correct when done in the create/edit view. But once saved and reloaded, the items were sorted by UUID (i.e. by array keys) instead of keeping their manually attributed order.