### PR TITLE
Fix: extra form fields not filled

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -100,11 +100,11 @@ trait HandlesNavigationBuilder
                             // NOTE: This chunk of code is a workaround for Livewire not letting
                             //       you entangle to non-existent array keys, which wire:model
                             //       would normally let you do.
-                            $component
-                                ->getContainer()
-                                ->getComponent(fn (Component $component) => $component instanceof Group)
-                                ->getChildComponentContainer()
-                                ->fill();
+                            foreach ($component->getContainer()->getComponents() as $component) {
+                                if ($component instanceof Group) {
+                                    $component->getChildComponentContainer()->fill();
+                                }
+                            }
                         })
                         ->reactive(),
                     Group::make()


### PR DESCRIPTION
Apparently the extra form fields are not filled, causing any (custom) components in the `->withExtraFields()` that use entangle to crash on the Livewire missing property.

Thanks!